### PR TITLE
Made dependency on lottie-ios package safe

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
             targets: ["LottieUI"]),
     ],
     dependencies: [
-        .package(name: "Lottie", url: "https://github.com/airbnb/lottie-ios.git", .branch("master"))
+        .package(name: "Lottie", url: "https://github.com/airbnb/lottie-ios.git", .upToNextMajor(from: "3.0.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Hello, @jasudev, good work on porting `lottie-ios` package to `SwiftUI`!

I saw that the dependency on the `lottie-ios` package is not safe, because the `.branch("master")` versioning rule is set, which means that if the major version of the library incremented _(backward incompatible changes are introduced)_, then this library will also receive this version and it could stop working, due to API incompatibility. That is why I changed the versioning rule to be `upToNextMajor(from: "3.0.0")` which means that library will depend only on those versions that are greater than 3.0.0 and lower than 4.0.0 
