### PR TITLE
Updated Lottie dependency url

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
             targets: ["LottieUI"]),
     ],
     dependencies: [
-        .package(name: "Lottie", url: "https://github.com/airbnb/lottie-ios.git", branch: "master")
+        .package(name: "Lottie", url: "https://github.com/airbnb/lottie-spm.git", branch: "main")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Their documentation states:

When using Swift Package Manager we recommend using the lottie-spm repo instead of the main lottie-ios repo. The main git repository for lottie-ios is somewhat large (300+ MB), and Swift Package Manager always downloads the full repository with all git history. The lottie-spm repo is much smaller (less than 500kb), so can be downloaded much more quickly.